### PR TITLE
Update build system to use rebar3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-REBAR?=./rebar
+REBAR?=rebar3
 
 
 all: build

--- a/rebar.config
+++ b/rebar.config
@@ -7,14 +7,19 @@
 ]}.
 
 {port_env, [
+    % Drop -lerl_interface
+    {"ERL_LDFLAGS", " -L$ERL_EI_LIBDIR -lei"},
+    {"win32", "ERL_LDFLAGS", " /LIBPATH:$ERL_EI_LIBDIR ei.lib"},
+
+    {".*", "FLTO_FLAG", ""},
 
     {"(linux|solaris|freebsd|netbsd|openbsd|dragonfly|darwin|gnu)",
-        "CFLAGS", "$CFLAGS -Ic_src/ -g -Wall -Werror -O3"},
+        "CFLAGS", "$CFLAGS -Ic_src/ -g -Wall $FLTO_FLAG -Werror -O3"},
     {"(linux|solaris|freebsd|netbsd|openbsd|dragonfly|darwin|gnu)",
-        "CXXFLAGS", "$CXXFLAGS -Ic_src/ -g -Wall -Werror -O3"},
+        "CXXFLAGS", "$CXXFLAGS -Ic_src/ -g -Wall $FLTO_FLAG -Werror -O3"},
 
     {"(linux|solaris|freebsd|netbsd|openbsd|dragonfly|darwin|gnu)",
-        "LDFLAGS", "$LDFLAGS -lstdc++"},
+        "LDFLAGS", "$LDFLAGS $FLTO_FLAG -lstdc++"},
 
     %% OS X Leopard flags for 64-bit
     {"darwin9.*-64$", "CXXFLAGS", "-m64"},
@@ -34,6 +39,3 @@
 {eunit_opts, [
     verbose
 ]}.
-
-{pre_hooks, [{"", compile, "escript enc compile"}]}.
-{post_hooks, [{"", clean, "escript enc clean"}]}.

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -9,11 +9,57 @@ ErlOpts = if not HaveEQC -> []; true ->
     [{d, 'HAVE_EQC'}]
 end,
 
-case lists:keyfind(erl_opts, 1, CONFIG) of
+Config1 = case lists:keyfind(erl_opts, 1, CONFIG) of
     {erl_opts, Opts} ->
         NewOpts = {erl_opts, Opts ++ ErlOpts},
         lists:keyreplace(erl_opts, 1, CONFIG, NewOpts);
     false ->
         CONFIG ++ [{erl_opts, ErlOpts}]
-end.
+end,
 
+Config2 = case os:type() of
+    {unix, _} ->
+        CC = case os:getenv("CC") of
+            false -> "cc";
+            Else -> Else
+        end,
+        FLTO_CHECK = "echo 'int main(int argc, char *argv[]) {return 0;}' | "
+                ++ CC ++ " -c -x c -o /dev/null -flto -",
+        case os:cmd(FLTO_CHECK) of
+            [] ->
+                {port_env, PortEnv} = lists:keyfind(port_env, 1, Config1),
+                NewFlag = {".*", "FLTO_FLAG", "-flto"},
+                NewPortEnv = lists:keyreplace("FLTO_FLAG", 2, PortEnv, NewFlag),
+                lists:keyreplace(port_env, 1, Config1, {port_env, NewPortEnv});
+            _ ->
+                Config1
+        end;
+    _ ->
+        Config1
+end,
+
+IsRebar2 = case lists:keyfind(rebar, 1, application:loaded_applications()) of
+    {rebar, _Desc, Vsn} ->
+        case string:split(Vsn, ".") of
+            ["2" | _] -> true;
+            _ -> false
+        end;
+    false ->
+        false
+end,
+
+case IsRebar2 of
+    true ->
+        Config2;
+    false ->
+        Config2 ++ [
+            {plugins, [{pc, "~> 1.0"}]},
+            {artifacts, ["priv/jiffy.so"]},
+            {provider_hooks, [
+                {post, [
+                    {compile, {pc, compile}},
+                    {clean, {pc, clean}}
+                ]}
+            ]}
+        ]
+end.

--- a/src/jiffy.app.src
+++ b/src/jiffy.app.src
@@ -11,7 +11,6 @@
         "Makefile",
         "README.md",
         "c_src",
-        "enc",
         "plugins",
         "rebar.config",
         "rebar.config.script",


### PR DESCRIPTION
This was mostly copy/pasted from the upstream build. It appears to work, and is a prerequisite for OTP25, as rebar (not rebar3) is not supported on OTP25.

This succeeds #2 